### PR TITLE
Enable Cross-Origin Resource Sharing (CORS)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,11 @@
 import os
 from flask import Flask, request, render_template, send_from_directory
+from flask_cors import CORS
 import iss
 from util import safe_float, json, jsonp
 
 app = Flask(__name__)
+CORS(app)
 
 # APIs:
 API_DEFS = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ newrelic==2.66.0.49
 pyephem==3.7.6.0
 redis==2.10.5
 Werkzeug==0.11.10
+Flask-Cors==3.0.6


### PR DESCRIPTION
Implement the Flask-Cors package to allow cross-origin resource sharing (CORS). This will add the following line to response headers served by the API:
`Access-Control-Allow-Origin: *`

When a client sends a request to the API from a different domain, the browser will block the response unless `Access-Control-Allow-Origin: *` is included in the header of the response. This update will enable clients from other domains to use the API.


